### PR TITLE
Fix for pp.x -- writing out the density on a real-space grid.

### DIFF
--- a/ABINIT/OBF_dft.pl
+++ b/ABINIT/OBF_dft.pl
@@ -321,6 +321,7 @@ if ($RunESPRESSO) {
           . "  plot_num = 0\n"
           . "/\n"
           . "&plot\n"
+          . "  plot_center_atom = -1\n"
           . "  nfile = 1\n"
           . "  filepp(1) = 'system.rho', weight(1) = 1\n"
           . "  iflag = 3\n"


### PR DESCRIPTION
In QE4.3 the default will shift the grid to the center of mass of the cell.
OCEAN needs this grid to not be messed with. PP/chdens.f90 must be patched
to allow reasonable behavior (fixed in QE5). This commit changes the input
file pp.in.
