### PR TITLE
Bug: transposed bvecs in OCEAN_bubble:gvec_length

### DIFF
--- a/OCEAN2/OCEAN_bubble.f90
+++ b/OCEAN2/OCEAN_bubble.f90
@@ -41,9 +41,9 @@ module OCEAN_bubble
     real(dp) :: bvec(3,3)
     !
     !write(71,*) gvec(:) 
-    length = ( bvec(1,1) * dble(gvec(1)) + bvec(2,1) * dble(gvec(2)) + bvec(3,1) * dble(gvec(3)) ) ** 2.0_dp &
-           + ( bvec(1,2) * dble(gvec(1)) + bvec(2,2) * dble(gvec(2)) + bvec(3,2) * dble(gvec(3)) ) ** 2.0_dp &
-           + ( bvec(1,3) * dble(gvec(1)) + bvec(2,3) * dble(gvec(2)) + bvec(3,3) * dble(gvec(3)) ) ** 2.0_dp
+    length = ( bvec(1,1) * dble(gvec(1)) + bvec(1,2) * dble(gvec(2)) + bvec(1,3) * dble(gvec(3)) ) ** 2.0_dp &
+           + ( bvec(2,1) * dble(gvec(1)) + bvec(2,2) * dble(gvec(2)) + bvec(2,3) * dble(gvec(3)) ) ** 2.0_dp &
+           + ( bvec(3,1) * dble(gvec(1)) + bvec(3,2) * dble(gvec(2)) + bvec(3,3) * dble(gvec(3)) ) ** 2.0_dp
   end function gvec_length
 
   subroutine AI_bubble_clean( )

--- a/OCEAN2/optim.f90
+++ b/OCEAN2/optim.f90
@@ -29,7 +29,7 @@ function optim( nmin, nfac, fac, locap, hicap )
   powmax( : ) = powmin( : ) 
   do j = 1, nfac
      i = nbase
-     do while ( i .lt. nmin )
+     do while ( i .le. nmin )
         powmax( j ) = powmax( j ) + 1
         i = i * fac( j )
      end do
@@ -47,7 +47,7 @@ function optim( nmin, nfac, fac, locap, hicap )
      do j = 1, nfac
         ntest = ntest * fac( j ) ** pow( j )
      end do
-     if ( ( ntest .gt. nmin ) .and. ( ntest .le. n ) ) n = ntest
+     if ( ( ntest .ge. nmin ) .and. ( ntest .le. n ) ) n = ntest
      call reginc( nfac, pow, powmin, powmax, valid )
   end do
   deallocate( pow, powmin, powmax )


### PR DESCRIPTION
Fixed a problem in the function gvec_length which would manifest for large differences in the length of the 3 unit cell vectors (technically of the inverse)

Also fixed the optim function to give more optimal FFT grids