### PR TITLE
Fixing issue with parsing UPF header

### DIFF
--- a/Common/psp_parser.pl
+++ b/Common/psp_parser.pl
@@ -252,7 +252,7 @@ sub upfParser
       }
       last;
     } 
-    elsif( $line =~ m/element\s*="\s*(\w+)/i ) {
+    if( $line =~ m/element\s*="\s*(\w+)/i ) {
       $element = $1;
     }
 #    last if( $n != -1 && $element ne "" );

--- a/OPF/validate_opts.pl
+++ b/OPF/validate_opts.pl
@@ -35,7 +35,8 @@ if( $ARGV[0] =~ m/upf$/i ) {
       $z = &symb2z( $element );
       print "$element $z\n";
       last if( defined( $z_eff ) );
-    } elsif( $line =~ m/(\d+\.?\d*)\s+Z valence/i || $line =~ m/z_valence="(\d+\.?\d*([Ee][+-]\d+)?)"/i ) {
+    }
+    if( $line =~ m/(\d+\.?\d*)\s+Z valence/i || $line =~ m/z_valence="(\d+\.?\d*([Ee][+-]\d+)?)"/i ) {
       $z_eff = $1*1;
       print "$z_eff\n";
       last if( defined( $z ) );


### PR DESCRIPTION
When experimenting with different pseudopotentials, I noticed that ocean fails with the error `Failed to validate options file` when using UPFs generated with quantum espresso. This PR fixes this by updating validate_opts.pl to handle the case where the header fields are all on the same line. It also makes the same change to psp_parser.pl.